### PR TITLE
Use custom form login block so page title isn't overwritten

### DIFF
--- a/app/code/local/EcomDev/Bootstrap/Block/Customer/Form/Login.php
+++ b/app/code/local/EcomDev/Bootstrap/Block/Customer/Form/Login.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Customer login form block
+ *
+ * @category   EcomDev
+ * @package    EcomDev_Bootstrap
+ * @author     Chris Jones <leeked@gmail.com>
+ */
+class EcomDev_Bootstrap_Block_Customer_Form_Login extends Mage_Customer_Block_Form_Login
+{
+    /**
+     * Override parent functionality so Form_Login block can be used
+     * without having it override every page title.
+     */
+    protected function _prepareLayout()
+    {
+        return Mage_Core_Block_Template::_prepareLayout();
+    }
+}

--- a/app/code/local/EcomDev/Bootstrap/etc/config.xml
+++ b/app/code/local/EcomDev/Bootstrap/etc/config.xml
@@ -41,6 +41,11 @@
         </layout>
     </frontend>
     <global>
+        <blocks>
+            <ecomdev_bootstrap>
+                <class>EcomDev_Bootstrap_Block</class>
+            </ecomdev_bootstrap>
+        </blocks>
         <models>
             <ecomdev_bootstrap>
                 <class>EcomDev_Bootstrap_Model</class>

--- a/app/design/frontend/mbootstrap/default/layout/mbootstrap.xml
+++ b/app/design/frontend/mbootstrap/default/layout/mbootstrap.xml
@@ -186,7 +186,7 @@
             </reference>
 
             <reference name="before_document_end">
-                <block type="customer/form_login" name="customer_form_login_modal" template="persistent/customer/form/login_modal.phtml" />
+                <block type="ecomdev_bootstrap/customer_form_login" name="customer_form_login_modal" template="persistent/customer/form/login_modal.phtml" />
             </reference>
 
         </reference>


### PR DESCRIPTION
`Mage_Customer_Block_Form_Login` sets the page title of every page to "Customer Login" - using this custom block for the modal fixes that.
