### PR TITLE
Wishlist Top Link shows even if wishlist is disabled

### DIFF
--- a/app/design/frontend/mbootstrap/default/layout/mbootstrap.xml
+++ b/app/design/frontend/mbootstrap/default/layout/mbootstrap.xml
@@ -66,7 +66,7 @@
                             <prepare/><urlParams/><position>100</position><liParams/>
                             <aParams/><beforeText><![CDATA[<i class="glyphicon glyphicon-user"></i>]]></beforeText>
                         </action>
-                        <action method="addLink" translate="label title" module="wishlist">
+                        <action method="addLink" translate="label title" module="wishlist" ifconfig="wishlist/general/active">
                             <label>My Wishlist</label><url helper="wishlist/getListUrl"/><title>My Wishlist</title>
                             <prepare/><urlParams/><position>200</position><liParams>hidden-phone</liParams>
                             <aParams/><beforeText><![CDATA[<i class="glyphicon glyphicon-bookmark"></i>]]></beforeText>


### PR DESCRIPTION
This PR makes the wish list `top-link` respect the system config setting and show only if enabled.
